### PR TITLE
[Add] Separate shared data into sub dirs by default.

### DIFF
--- a/du.sh
+++ b/du.sh
@@ -2,7 +2,8 @@
 CONTAINERS="apache php phpcli adminer mysql56 selenium mailhog node"
 
 if [ -z "$DOCKER_SHARED_PATH" ]; then
-    DOCKER_SHARED_PATH=~/docker
+    DIR=$(basename "$PWD")
+    DOCKER_SHARED_PATH=~/docker/${DIR}
     echo "Setting default shared path to $DOCKER_SHARED_PATH "
 fi
 


### PR DESCRIPTION
- Having all projects share folders for evenything (logs, mysql, solr, caches, etc) can be problematic. E.g. mixing mysql versions, or logs overwriting each other.
- Projects now store their own data (mysql, logs, etc) into `~/docker/<project dir>`. So if your website project is in a dir `.../web` then the docker files will go into `~/docker/web`.

This doesn't prevent defining a custom dir in a `.env` file, it's just to have a more desirable default setup (also the `.env` thing doesn't seem to work, so it's a workaround for that).