### PR TITLE
add stack limit for Elastic Search

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,7 @@ services:
       - "http.host=0.0.0.0"
       - "transport.host=127.0.0.1"
       - "xpack.security.enabled=false"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     volumes:
       - ${DOCKER_PROJECT_PATH}/elastic-data:/usr/share/elasticsearch/data
 


### PR DESCRIPTION
For CI we need to limit the size of the stack for Elastic Search. This will limit each instance to use 512M.